### PR TITLE
fix: デフォルトセット数を8から9に変更

### DIFF
--- a/HIIT_exercise_time_keeper/index.html
+++ b/HIIT_exercise_time_keeper/index.html
@@ -11,7 +11,7 @@
         <header>
             <h1>HIITタイマー</h1>
             <div class="set-counter">
-                セット <span id="currentSet">1</span> / <span id="totalSets">8</span>
+                セット <span id="currentSet">1</span> / <span id="totalSets">9</span>
             </div>
         </header>
 
@@ -39,7 +39,7 @@
                     <div class="progress-bar">
                         <div class="progress-fill overall" id="overallProgress"></div>
                     </div>
-                    <div class="progress-text" id="overallProgressText">セット 1/8 完了</div>
+                    <div class="progress-text" id="overallProgressText">セット 1/9 完了</div>
                 </div>
                 
                 <div class="stats-container">
@@ -49,7 +49,7 @@
                     </div>
                     <div class="stat-item">
                         <div class="stat-label">予想終了時間</div>
-                        <div class="stat-value" id="estimatedEndTime">04:00</div>
+                        <div class="stat-value" id="estimatedEndTime">04:30</div>
                     </div>
                 </div>
             </div>
@@ -93,7 +93,7 @@
                 <div class="setting-row">
                     <label for="setCountInput">セット数:</label>
                     <div class="input-group">
-                        <input type="number" id="setCountInput" min="1" max="99" value="8" class="time-input">
+                        <input type="number" id="setCountInput" min="1" max="99" value="9" class="time-input">
                         <span class="input-unit">セット</span>
                     </div>
                 </div>

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -19,7 +19,7 @@ const timer = {
     settings: {
         workTime: 20,
         restTime: 10,
-        totalSets: 8,
+        totalSets: 9,
         audioEnabled: true,
         volume: 0.7
     }
@@ -98,7 +98,7 @@ const presetSystem = {
             name: 'タバタ式',
             workTime: 20,
             restTime: 10,
-            totalSets: 8,
+            totalSets: 9,
             audioEnabled: true,
             volume: 0.7
         },


### PR DESCRIPTION
## Summary
デフォルトのセット数を8から9に変更しました。

## 変更内容
- HTMLの初期表示値を9に変更
- JavaScriptのデフォルト設定を9に変更  
- タバタ式プリセットも9セットに変更
- 予想終了時間の初期表示を調整（04:30）

## 影響範囲
- 新規ユーザーのデフォルト体験
- タバタ式プリセットの設定
- 初期表示の統一性

🤖 Generated with [Claude Code](https://claude.ai/code)