### PR TITLE
feat: 軸入れ替えと大胆なUIアップデート

### DIFF
--- a/HIIT_exercise_time_keeper/index.html
+++ b/HIIT_exercise_time_keeper/index.html
@@ -11,9 +11,9 @@
 
         <main>
             <div class="timer-display">
-                <div class="vertical-progress-bar" id="verticalProgressBar">
-                    <div class="vertical-progress-fill" id="verticalProgress"></div>
-                    <div class="vertical-set-dividers" id="verticalSetDividers"></div>
+                <div class="horizontal-progress-bar" id="horizontalProgressBar">
+                    <div class="horizontal-progress-fill" id="horizontalProgress"></div>
+                    <div class="horizontal-set-dividers" id="horizontalSetDividers"></div>
                 </div>
                 
                 <div class="timer-content">

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -187,9 +187,9 @@ const elements = {
     setCountInput: document.getElementById('setCountInput'),
     applySettingsBtn: document.getElementById('applySettingsBtn'),
     // 進捗表示関連の要素
-    verticalProgressBar: document.getElementById('verticalProgressBar'),
-    verticalProgress: document.getElementById('verticalProgress'),
-    verticalSetDividers: document.getElementById('verticalSetDividers')
+    horizontalProgressBar: document.getElementById('horizontalProgressBar'),
+    horizontalProgress: document.getElementById('horizontalProgress'),
+    horizontalSetDividers: document.getElementById('horizontalSetDividers')
 };
 
 // 初期表示の更新
@@ -204,8 +204,8 @@ function updateDisplay() {
     // 進捗表示の更新
     updateProgressDisplay();
     
-    // 縦セット区切り線の作成
-    createVerticalSetDividers();
+    // 横セット区切り線の作成
+    createHorizontalSetDividers();
 }
 
 // タイマーの状態に応じた表示の更新
@@ -214,25 +214,25 @@ function updateTimerStyle() {
     
     switch (timer.state) {
         case TimerState.PREPARE:
-            elements.status.textContent = '準備時間';
+            elements.status.textContent = 'READY!!!';
             break;
         case TimerState.WORK:
             elements.timerDisplay.classList.add('work');
-            elements.status.textContent = `運動中 - セット ${timer.currentSet}`;
+            elements.status.textContent = 'WORKING!!!';
             // 運動開始音を再生
             audioSystem.playWorkStart();
             break;
         case TimerState.REST:
             elements.timerDisplay.classList.add('rest');
-            elements.status.textContent = `休憩中 - セット ${timer.currentSet}`;
+            elements.status.textContent = 'REST';
             // 休憩開始音を再生
             audioSystem.playRestStart();
             break;
         case TimerState.IDLE:
-            elements.status.textContent = '準備時間';
+            elements.status.textContent = 'READY!!!';
             break;
         case TimerState.FINISHED:
-            elements.status.textContent = '完了！';
+            elements.status.textContent = 'FINISHED!';
             // 完了音を再生
             audioSystem.playFinish();
             break;
@@ -271,9 +271,9 @@ function updateTimerBackgroundGradient() {
         return;
     }
     
-    // 線形グラデーションで進捗を表示（左から右へ）
+    // 線形グラデーションで進捗を表示（上から下へ）
     elements.timerDisplay.style.background = 
-        `linear-gradient(to right, ${progressColor} ${progress}%, ${remainingColor} ${progress}%)`;
+        `linear-gradient(to bottom, ${progressColor} ${progress}%, ${remainingColor} ${progress}%)`;
 }
 
 // 進捗表示を更新
@@ -299,21 +299,33 @@ function updateProgressDisplay() {
     
     const overallProgressPercent = ((completedSets + currentSetProgress) / timer.settings.totalSets) * 100;
     
-    elements.verticalProgress.style.height = overallProgressPercent + '%';
+    elements.horizontalProgress.style.width = overallProgressPercent + '%';
 }
 
-// 縦セット区切り線を作成
-function createVerticalSetDividers() {
+// 横セット区切り線を作成
+function createHorizontalSetDividers() {
     // 既存の区切り線を削除
-    elements.verticalSetDividers.innerHTML = '';
+    elements.horizontalSetDividers.innerHTML = '';
+    
+    // 各セットの領域にセット番号を表示
+    for (let i = 0; i < timer.settings.totalSets; i++) {
+        const setLabel = document.createElement('div');
+        setLabel.className = 'horizontal-set-label';
+        const leftPosition = (i / timer.settings.totalSets) * 100;
+        const width = (1 / timer.settings.totalSets) * 100;
+        setLabel.style.left = leftPosition + '%';
+        setLabel.style.width = width + '%';
+        setLabel.textContent = i + 1;
+        elements.horizontalSetDividers.appendChild(setLabel);
+    }
     
     // セット数に応じて区切り線を作成
     for (let i = 1; i < timer.settings.totalSets; i++) {
         const dividerLine = document.createElement('div');
-        dividerLine.className = 'vertical-divider-line';
+        dividerLine.className = 'horizontal-divider-line';
         const position = (i / timer.settings.totalSets) * 100;
-        dividerLine.style.bottom = position + '%';
-        elements.verticalSetDividers.appendChild(dividerLine);
+        dividerLine.style.left = position + '%';
+        elements.horizontalSetDividers.appendChild(dividerLine);
     }
 }
 
@@ -492,8 +504,8 @@ function applySettings() {
     updateDisplay();
     updateTimerStyle();
     
-    // 縦セット区切り線を再作成
-    createVerticalSetDividers();
+    // 横セット区切り線を再作成
+    createHorizontalSetDividers();
     
     // 設定パネルを閉じる
     elements.settingsPanel.classList.add('hidden');

--- a/HIIT_exercise_time_keeper/style.css
+++ b/HIIT_exercise_time_keeper/style.css
@@ -35,26 +35,26 @@ body {
 }
 
 
-.vertical-progress-bar {
+.horizontal-progress-bar {
     position: absolute;
     left: 0;
     top: 0;
     width: 100%;
     height: 100%;
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 100%);
+    background: linear-gradient(to right, rgba(255, 255, 255, 0.1) 0%, rgba(255, 255, 255, 0.05) 100%);
 }
 
-.vertical-progress-fill {
+.horizontal-progress-fill {
     position: absolute;
-    bottom: 0;
     left: 0;
-    width: 100%;
-    background: linear-gradient(to top, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.1) 100%);
-    transition: height 0.5s ease;
-    height: 0%;
+    top: 0;
+    height: 100%;
+    background: linear-gradient(to right, rgba(255, 255, 255, 0.3) 0%, rgba(255, 255, 255, 0.1) 100%);
+    transition: width 0.5s ease;
+    width: 0%;
 }
 
-.vertical-set-dividers {
+.horizontal-set-dividers {
     position: absolute;
     top: 0;
     left: 0;
@@ -63,12 +63,31 @@ body {
     pointer-events: none;
 }
 
-.vertical-divider-line {
+.horizontal-set-label {
     position: absolute;
-    left: 0;
-    width: 100%;
-    height: 1px;
-    background: linear-gradient(to right, transparent 0%, rgba(255, 255, 255, 0.4) 50%, transparent 100%);
+    top: 0;
+    height: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
+    padding-left: 10px;
+    padding-top: 20px;
+    font-size: 200px;
+    font-weight: 900;
+    color: rgba(255, 255, 255, 0.15);
+    text-shadow: none;
+    pointer-events: none;
+    z-index: 2;
+    overflow: hidden;
+}
+
+.horizontal-divider-line {
+    position: absolute;
+    top: 0;
+    height: 100%;
+    width: 1px;
+    background: linear-gradient(to bottom, transparent 0%, rgba(255, 255, 255, 0.4) 50%, transparent 100%);
+    z-index: 6;
 }
 
 .timer-content {
@@ -76,32 +95,51 @@ body {
     z-index: 10;
     height: 100%;
     display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-    padding: 60px 40px;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: stretch;
+    text-align: left;
+    padding: 0;
 }
 
 .timer-content .status,
 .timer-content .time-display {
     color: white;
-    text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.timer-content .status {
+    text-shadow: none;
+}
+
+.timer-content .time-display {
+    text-shadow: none;
 }
 
 .status {
-    font-size: 48px;
+    font-size: 200px;
     font-weight: bold;
-    margin-bottom: 30px;
     text-transform: uppercase;
-    letter-spacing: 4px;
+    letter-spacing: 12px;
+    display: flex;
+    align-items: flex-end;
+    padding-left: 40px;
+    padding-bottom: 40px;
+    flex: 1;
+    line-height: 0.8;
 }
 
 .time-display {
-    font-size: 280px;
+    font-size: 1200px;
     font-weight: bold;
-    line-height: 1;
+    line-height: 0.6;
     font-variant-numeric: tabular-nums;
+    text-align: right;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: 0;
+    overflow: hidden;
+    flex: 1;
 }
 
 


### PR DESCRIPTION
## Summary
- 進捗表示の軸を入れ替え（縦→横、横→縦）
- UIを大胆にアップデートしてより没入感のある体験に

## Changes
### 軸の入れ替え
- 進捗バー：縦方向から横方向（左→右）に変更
- タイマー背景：横方向から縦方向（上→下）に変更

### UI改善
- セット番号を背景に大きく薄く表示（200px、左上寄せ）
- 状態表示を英語化
  - 準備時間：READY\!\!\!
  - 運動中：WORKING\!\!\!
  - 休憩中：REST
  - 完了：FINISHED\!
- 数字を1200pxの巨大サイズで右寄せ
- 文字を200pxで左下寄せ
- テキストシャドウを削除してクリーンな表示

## Screenshot
\![HIIT Timer - New UI](https://github.com/tatsuosakurai/claude_code_test/assets/xxx/xxx)

## Test plan
- [x] タイマーが正常に動作する
- [x] 進捗バーが左から右に進む
- [x] タイマー背景が上から下に変化する
- [x] セット番号が背景に表示される
- [x] 英語表示が正しく表示される
- [x] フルスクリーンで見切れが美しい

🤖 Generated with [Claude Code](https://claude.ai/code)