### PR TITLE
feat: 準備時間中に最初のメニューを表示

### DIFF
--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -220,7 +220,11 @@ function updateTimerStyle() {
     switch (timer.state) {
         case TimerState.PREPARE:
             elements.status.textContent = 'READY!!!';
-            elements.menuDisplay.textContent = '';
+            if (timer.settings.menu.length > 0 && timer.settings.menu[0]) {
+                elements.menuDisplay.textContent = `次は: ${timer.settings.menu[0]}`;
+            } else {
+                elements.menuDisplay.textContent = '';
+            }
             break;
         case TimerState.WORK:
             elements.timerDisplay.classList.add('work');


### PR DESCRIPTION
- READY\!の状態でも「次は: [最初のメニュー]」を表示
- ユーザーが次の運動内容を事前に確認できるように改善

🤖 Generated with [Claude Code](https://claude.ai/code)