### PR TITLE
メニュー入力の改善とデータ永続化

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(ccusage)",
       "Bash(open index.html)",
-      "Bash(git remote:*)"
+      "Bash(git remote:*)",
+      "Bash(python3:*)"
     ],
     "deny": []
   }

--- a/HIIT_exercise_time_keeper/index.html
+++ b/HIIT_exercise_time_keeper/index.html
@@ -23,6 +23,7 @@
                     <div class="time-display">
                         <span id="timeDisplay">10</span>
                     </div>
+                    <div class="menu-display" id="menuDisplay"></div>
                 </div>
             </div>
 
@@ -56,11 +57,9 @@
                 </div>
                 
                 <div class="setting-row">
-                    <label for="setCountInput">セット数:</label>
-                    <div class="input-group">
-                        <input type="number" id="setCountInput" min="1" max="20" value="9" class="time-input">
-                        <span class="input-unit">セット</span>
-                    </div>
+                    <label for="menuInput">メニュー:</label>
+                    <textarea id="menuInput" rows="3" placeholder="例: スクワット プランク 腕立て伏せ...
+スペースか改行で区切ってください。"></textarea>
                 </div>
                 
                 <button id="applySettingsBtn" class="apply-btn">設定を適用</button>

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -495,11 +495,13 @@ function validateSettings() {
     const totalSets = menu.length || 9; // メニューの数に応じてセット数を決定
     
     return { 
-        ...timer.settings, // 既存の設定をコピー
         workTime, 
         prepareTime, 
         totalSets,
-        menu
+        menu,
+        restTime: timer.settings.restTime,
+        audioEnabled: timer.settings.audioEnabled,
+        volume: timer.settings.volume
     };
 }
 

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -21,7 +21,7 @@ const timer = {
         workTime: 20,
         restTime: 10,
         prepareTime: 10,
-        totalSets: 9,
+        totalSets: 9, // 固定値（メニューの数で動的に変更）
         audioEnabled: true,
         volume: 0.7,
         menu: []
@@ -185,7 +185,6 @@ const elements = {
     // 設定関連の要素
     workTimeInput: document.getElementById('workTimeInput'),
     prepareTimeInput: document.getElementById('prepareTimeInput'),
-    setCountInput: document.getElementById('setCountInput'),
     menuInput: document.getElementById('menuInput'),
     applySettingsBtn: document.getElementById('applySettingsBtn'),
     // 進捗表示関連の要素
@@ -203,7 +202,6 @@ function updateDisplay() {
     // 設定入力フィールドの値を更新
     elements.workTimeInput.value = timer.settings.workTime;
     elements.prepareTimeInput.value = timer.settings.prepareTime;
-    elements.setCountInput.value = timer.settings.totalSets;
     elements.menuInput.value = timer.settings.menu.join(' ');
     
     // 進捗表示の更新
@@ -480,7 +478,6 @@ function finishTimer() {
 function validateSettings() {
     const workTime = parseInt(elements.workTimeInput.value);
     const prepareTime = parseInt(elements.prepareTimeInput.value);
-    const totalSets = parseInt(elements.setCountInput.value);
     const menuText = elements.menuInput.value.trim();
     
     // 値の検証
@@ -493,13 +490,9 @@ function validateSettings() {
         alert('準備時間は1〜999の間で入力してください');
         return false;
     }
-    
-    if (isNaN(totalSets) || totalSets < 1 || totalSets > 99) {
-        alert('セット数は1〜99の間で入力してください');
-        return false;
-    }
 
-    const menu = menuText.split(/[\s\n,]+/).filter(item => item).slice(0, 9);
+    const menu = menuText.split(/[\s\n,]+/).filter(item => item);
+    const totalSets = menu.length || 9; // メニューの数に応じてセット数を決定
     
     return { 
         ...timer.settings, // 既存の設定をコピー
@@ -576,11 +569,6 @@ elements.workTimeInput.addEventListener('input', (e) => {
 elements.prepareTimeInput.addEventListener('input', (e) => {
     if (e.target.value < 1) e.target.value = 1;
     if (e.target.value > 999) e.target.value = 999;
-});
-
-elements.setCountInput.addEventListener('input', (e) => {
-    if (e.target.value < 1) e.target.value = 1;
-    if (e.target.value > 99) e.target.value = 99;
 });
 
 

--- a/HIIT_exercise_time_keeper/style.css
+++ b/HIIT_exercise_time_keeper/style.css
@@ -305,6 +305,27 @@ body {
     font-size: 16px; /* Prevent zoom on iOS */
 }
 
+#menuInput {
+    width: 100%;
+    padding: 8px 12px;
+    border: 2px solid #ddd;
+    border-radius: 8px;
+    font-size: 14px;
+    resize: vertical;
+    margin-top: 5px;
+}
+
+.menu-display {
+    position: absolute;
+    bottom: 20px;
+    left: 20px;
+    font-size: 24px;
+    font-weight: bold;
+    color: white;
+    text-shadow: 1px 1px 3px rgba(0,0,0,0.5);
+    z-index: 11;
+}
+
 .time-input:invalid {
     border-color: #ff6b6b;
 }


### PR DESCRIPTION
## Summary
- メニュー入力でスペース、改行、カンマ区切りをサポート
- LocalStorageを使用して設定データを永続化
- セット数を自動でメニュー数から決定するように変更

## 変更内容
1. **メニュー入力の改善**
   - スペース、改行、カンマ（,）で区切って登録可能に
   - より柔軟な入力方法をサポート

2. **データの永続化**
   - ブラウザのlocalStorageに設定を保存
   - ページリロード後も設定が保持される

3. **UI/UXの改善**
   - 準備時間（READY\!）中にも次のメニューを表示
   - セット数の入力欄を削除し、メニュー数から自動決定

4. **バグ修正**
   - メニュー数を減らした時にセット数が正しく更新されない問題を修正

## Test plan
- [x] メニューをスペース区切りで入力して動作確認
- [x] メニューを改行区切りで入力して動作確認
- [x] メニューをカンマ区切りで入力して動作確認
- [x] ページをリロードして設定が保持されることを確認
- [x] READY\!状態で次のメニューが表示されることを確認
- [x] メニュー数を増減させてセット数が正しく変更されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)