### PR TITLE
メニュー入力欄の拡大とデフォルトメニューの設定

### DIFF
--- a/HIIT_exercise_time_keeper/index.html
+++ b/HIIT_exercise_time_keeper/index.html
@@ -58,7 +58,7 @@
                 
                 <div class="setting-row">
                     <label for="menuInput">メニュー:</label>
-                    <textarea id="menuInput" rows="3" placeholder="例: スクワット プランク 腕立て伏せ...
+                    <textarea id="menuInput" rows="10" placeholder="例: スクワット プランク 腕立て伏せ...
 スペースか改行で区切ってください。"></textarea>
                 </div>
                 

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -24,7 +24,17 @@ const timer = {
         totalSets: 9, // 固定値（メニューの数で動的に変更）
         audioEnabled: true,
         volume: 0.7,
-        menu: []
+        menu: [
+            '腕立て',
+            '腕立て(脇締め)',
+            'スクワット',
+            'バックランジ',
+            'バックランジニーアップ',
+            'マウンテンクライマー',
+            'マウンテンクライマー(ツイスト)',
+            'バービー',
+            'ニーアップ'
+        ]
     }
 };
 
@@ -202,7 +212,7 @@ function updateDisplay() {
     // 設定入力フィールドの値を更新
     elements.workTimeInput.value = timer.settings.workTime;
     elements.prepareTimeInput.value = timer.settings.prepareTime;
-    elements.menuInput.value = timer.settings.menu.join(' ');
+    elements.menuInput.value = timer.settings.menu.join('\n');
     
     // 進捗表示の更新
     updateProgressDisplay();


### PR DESCRIPTION
## Summary
- メニュー入力欄を10行に拡大
- デフォルトメニューを9種類のエクササイズに設定
- メニュー表示を改行区切りに変更

## デフォルトメニュー
1. 腕立て
2. 腕立て(脇締め)
3. スクワット
4. バックランジ
5. バックランジニーアップ
6. マウンテンクライマー
7. マウンテンクライマー(ツイスト)
8. バービー
9. ニーアップ

## Test plan
- [x] メニュー入力欄が10行表示されることを確認
- [x] デフォルトメニューが正しく表示されることを確認
- [x] メニューが改行で区切られて表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)