### PR TITLE
feat: コミット日時とハッシュ値を含むバージョン表示を追加

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,37 @@
+name: Update Version Info
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Get commit info
+      id: commit
+      run: |
+        echo "hash=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        echo "date=$(TZ=Asia/Tokyo date +'%Y.%m.%d-%H%M')" >> $GITHUB_OUTPUT
+    
+    - name: Update version.js
+      run: |
+        cat > HIIT_exercise_time_keeper/version.js << EOF
+        // バージョン情報を動的に設定
+        window.APP_VERSION = {
+            build: '${{ steps.commit.outputs.date }}-${{ steps.commit.outputs.hash }}',
+            timestamp: '$(date -u +"%Y-%m-%dT%H:%M:%SZ")'
+        };
+        EOF
+    
+    - name: Commit and push if changed
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add -A
+        git diff --staged --quiet || (git commit -m "chore: update version info [skip ci]" && git push)

--- a/HIIT_exercise_time_keeper/index.html
+++ b/HIIT_exercise_time_keeper/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
     <div class="container">
+        <div class="version-info" id="versionInfo"></div>
 
         <main>
             <div class="timer-display">
@@ -67,6 +68,7 @@
         </main>
     </div>
 
+    <script src="version.js"></script>
     <script src="viewport-height.js"></script>
     <script src="script.js"></script>
 </body>

--- a/HIIT_exercise_time_keeper/script.js
+++ b/HIIT_exercise_time_keeper/script.js
@@ -640,7 +640,17 @@ function saveSettings() {
     }
 }
 
+// バージョン情報を表示
+function displayVersion() {
+    const versionElement = document.getElementById('versionInfo');
+    if (window.APP_VERSION && versionElement) {
+        versionElement.textContent = `v${window.APP_VERSION.build}`;
+        versionElement.title = `Build: ${window.APP_VERSION.build}\nUpdated: ${window.APP_VERSION.timestamp}`;
+    }
+}
+
 // 初期化
 loadSettings();
 updateDisplay();
 updateTimerStyle();
+displayVersion();

--- a/HIIT_exercise_time_keeper/style.css
+++ b/HIIT_exercise_time_keeper/style.css
@@ -4,6 +4,22 @@
     box-sizing: border-box;
 }
 
+.version-info {
+    position: fixed;
+    bottom: 10px;
+    left: 10px;
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.6);
+    font-family: monospace;
+    z-index: 100;
+    cursor: help;
+    transition: color 0.3s ease;
+}
+
+.version-info:hover {
+    color: rgba(255, 255, 255, 0.9);
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);

--- a/HIIT_exercise_time_keeper/version.js
+++ b/HIIT_exercise_time_keeper/version.js
@@ -1,0 +1,5 @@
+// バージョン情報を動的に設定
+window.APP_VERSION = {
+    build: '2025.07.06-1035-74c19a3',  // デフォルト値（実際の値はCIで置換される）
+    timestamp: new Date().toISOString()
+};


### PR DESCRIPTION
## Summary
- 画面左下にバージョン情報を表示（フォーマット: v2025.07.06-1035-74c19a3）
- GitHub Actionsでmasterブランチへのpush時に自動的にバージョン情報を更新
- マウスホバーでビルド時刻の詳細を表示

## Test plan
- [ ] HIITタイマーアプリを開く
- [ ] 画面左下にバージョン番号が表示されることを確認
- [ ] バージョン番号にマウスをホバーすると詳細情報が表示されることを確認
- [ ] バージョン番号が控えめで邪魔にならないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)