### PR TITLE
feat: ボタンを画面下部に配置してiPhoneでの操作性を改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,11 @@
       "Bash(ccusage)",
       "Bash(open index.html)",
       "Bash(git remote:*)",
-      "Bash(python3:*)"
+      "Bash(python3:*)",
+      "Bash(gh pr create:*)",
+      "Bash(git restore:*)",
+      "Bash(TZ:*)",
+      "Bash(git pull:*)"
     ],
     "deny": []
   }

--- a/HIIT_exercise_time_keeper/style.css
+++ b/HIIT_exercise_time_keeper/style.css
@@ -141,7 +141,7 @@ body {
     align-items: flex-end;
     text-align: left;
     padding: 0;
-    padding-bottom: calc(40px + env(safe-area-inset-bottom));
+    padding-bottom: calc(100px + env(safe-area-inset-bottom));
 }
 
 .timer-content .status,
@@ -216,19 +216,23 @@ body {
 
 .controls {
     position: fixed;
-    top: calc(20px + env(safe-area-inset-top));
-    right: calc(20px + env(safe-area-inset-right));
+    bottom: calc(20px + env(safe-area-inset-bottom));
+    left: 50%;
+    transform: translateX(-50%);
     display: flex;
     gap: 15px;
-    justify-content: flex-end;
+    justify-content: center;
     z-index: 20;
+    width: 100%;
+    max-width: 400px;
+    padding: 0 20px;
 }
 
 .control-btn {
-    padding: 15px;
+    padding: 18px 24px;
     font-size: 16px;
     border: none;
-    border-radius: 12px;
+    border-radius: 16px;
     cursor: pointer;
     background: rgba(255, 255, 255, 0.2);
     color: white;
@@ -236,11 +240,13 @@ body {
     display: flex;
     align-items: center;
     gap: 8px;
-    min-width: 50px;
-    min-height: 50px;
+    min-width: 60px;
+    min-height: 60px;
     justify-content: center;
     backdrop-filter: blur(10px);
     -webkit-tap-highlight-color: transparent;
+    flex: 1;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
 .btn-icon {
@@ -286,6 +292,16 @@ body {
 
 .control-btn.long-pressing {
     animation: longPressAnimation 1s ease-in-out;
+}
+
+/* プライマリボタンを強調 */
+.control-btn.primary {
+    background: rgba(255, 255, 255, 0.3);
+    font-weight: 600;
+}
+
+.control-btn.primary:hover:not(:disabled) {
+    background: rgba(255, 255, 255, 0.4);
 }
 
 
@@ -663,7 +679,7 @@ body {
         flex-direction: column;
         align-items: stretch;
         padding: 20px;
-        padding-bottom: calc(30px + env(safe-area-inset-bottom));
+        padding-bottom: calc(80px + env(safe-area-inset-bottom));
         justify-content: flex-end;
     }
     
@@ -685,18 +701,16 @@ body {
     }
     
     .controls {
-        top: calc(20px + env(safe-area-inset-top));
-        right: auto;
-        left: 50%;
-        transform: translateX(-50%);
+        bottom: calc(15px + env(safe-area-inset-bottom));
         gap: 10px;
+        padding: 0 15px;
     }
     
     .control-btn {
-        padding: 12px;
+        padding: 15px 20px;
         font-size: 15px;
-        min-width: 44px;
-        min-height: 44px;
+        min-width: 50px;
+        min-height: 50px;
     }
     
     .settings {
@@ -735,18 +749,19 @@ body {
     
     .timer-content {
         padding: 15px;
-        padding-bottom: calc(20px + env(safe-area-inset-bottom));
+        padding-bottom: calc(70px + env(safe-area-inset-bottom));
     }
     
     .controls {
         gap: 8px;
+        bottom: calc(10px + env(safe-area-inset-bottom));
     }
     
     .control-btn {
-        padding: 10px;
+        padding: 12px 16px;
         font-size: 14px;
-        min-width: 40px;
-        min-height: 40px;
+        min-width: 44px;
+        min-height: 44px;
     }
     
     .btn-icon {
@@ -775,7 +790,7 @@ body {
     .timer-content {
         flex-direction: row;
         padding: 10px;
-        padding-bottom: calc(20px + env(safe-area-inset-bottom));
+        padding-bottom: calc(60px + env(safe-area-inset-bottom));
     }
     
     .status {
@@ -789,14 +804,25 @@ body {
     }
     
     .controls {
-        top: calc(10px + env(safe-area-inset-top));
+        bottom: calc(10px + env(safe-area-inset-bottom));
+        right: calc(20px + env(safe-area-inset-right));
+        left: auto;
+        transform: none;
+        max-width: none;
+        width: auto;
+        padding: 0;
     }
     
     .control-btn {
-        padding: 8px;
-        font-size: 13px;
-        min-width: 36px;
-        min-height: 36px;
+        padding: 18px 24px;
+        font-size: 16px;
+        min-width: 130px;
+        min-height: 60px;
+        flex: 0 0 auto;
+    }
+    
+    .btn-icon {
+        font-size: 24px;
     }
     
     .horizontal-set-label {


### PR DESCRIPTION
## Summary
- コントロールボタンを画面下部中央に配置してアクセシビリティを向上
- iPhoneでの片手操作を考慮した設計
- 横向き時は右下配置で最適なレイアウトを実現

## Changes
- ボタンを画面上部から下部に移動
- ボタンサイズを60x60pxに拡大
- 横向き時は右下配置（幅130px）で間延びを防止
- Safe Area Insetsを適切に設定
- タイマー表示エリアの下部パディングを調整

## Test plan
- [ ] iPhoneでHIITタイマーアプリを開く
- [ ] 縦向きでボタンが画面下部中央に表示されることを確認
- [ ] ボタンが十分な大きさで押しやすいことを確認
- [ ] 横向きにしてボタンが右下に適切に配置されることを確認
- [ ] タイマー表示とボタンが重ならないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)